### PR TITLE
allow extension including capital chars

### DIFF
--- a/app/api/upload.php
+++ b/app/api/upload.php
@@ -30,7 +30,7 @@ if($filesize > $max_file_size*1024*1024){
 
 //ファイル拡張子
 $ext = substr( $_FILES['file']['name'], strrpos( $_FILES['file']['name'], '.') + 1);
-if(in_array($ext, $extension) === false){
+if(in_array(mb_strtolower($ext), $extension) === false){
   $response = array('status' => 'extension_error', 'ext' => $ext);
   //JSON形式で出力する
   echo json_encode( $response );


### PR DESCRIPTION
拡張子に大文字を含んでいても許可するように。
$extで切り出した拡張子をmb_strtolowerを適用するため$extensions はすべて小文字+数字で記述しなければならない。