### PR TITLE
拡張子を指定しないことを可能にした

### DIFF
--- a/app/api/upload.php
+++ b/app/api/upload.php
@@ -86,7 +86,7 @@ if($filesize > $max_file_size*1024*1024){
 
 //ファイル拡張子
 $ext = substr( $escaped_file_name, strrpos( $escaped_file_name, '.') + 1);
-if(in_array(mb_strtolower($ext), $extension) === false){
+if(!is_null($extension) and in_array(mb_strtolower($ext), $extension) === false){
   $response = array('status' => 'extension_error', 'ext' => $ext);
   //JSON形式で出力する
   echo json_encode( $response );

--- a/app/views/index.php
+++ b/app/views/index.php
@@ -9,11 +9,13 @@
           <input type="text" id="fileInput" class="form-control" name="file" placeholder="ファイルを選択...">
           <span class="input-group-btn"><button type="button" class="btn btn-primary" onclick="$('input[id=lefile]').click();">Browse</button></span>
         </div>
-        <p class="help-block"><?php echo $max_file_size; ?>MBまでのファイルがアップロードできます。<br>対応拡張子： <?php 
+        <p class="help-block"><?php echo $max_file_size; ?>MBまでのファイルがアップロードできます。<br>
+        <?php if (!is_null($extension)) { ?>
+          対応拡張子： <?php
           foreach($extension as $s){
             echo $s.' ';
           }
-         ?></p>
+        }?></p>
 
         <div class="form-group">
           <label for="commentInput">コメント</label>

--- a/config/config.php
+++ b/config/config.php
@@ -34,6 +34,7 @@ class config {
       'max_file_size'       => 2,
 
       // アップロードできる拡張子
+      // nullならば制限なし
       'extension'           => array('zip','rar','lzh'),
 
       // データベースディレクトリ


### PR DESCRIPTION
`config` の `extension` は拡張子の配列でありますが、ここに `null` を設定することでファイルのアップロードの拡張子の制限をなくすことを可能にしました。