### PR TITLE
Fix uploaded metadata disclosure and release 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-06-29
+
+### Security
+
+- ファイル一覧画面に公開するアップロード情報を必要な表示用メタデータのみに制限
+- ファイル一覧データをインラインJavaScriptへ埋め込む際のJSONエスケープを強化
+
 ## [2.0.1] - 2025-08-03
 
 ### Fixed

--- a/app/models/index.php
+++ b/app/models/index.php
@@ -4,6 +4,15 @@ namespace PHPUploader\Model;
 
 class Index
 {
+    public const PUBLIC_FILE_COLUMNS = [
+        'id',
+        'origin_file_name',
+        'comment',
+        'size',
+        'count',
+        'input_date',
+    ];
+
     public function index()
     {
         $config = new \PHPUploader\Config();
@@ -27,8 +36,8 @@ class Index
         // (毎回\PDO::FETCH_ASSOCを指定する必要が無くなる)
         $db->setAttribute(\PDO::ATTR_DEFAULT_FETCH_MODE, \PDO::FETCH_ASSOC);
 
-        // 選択 (プリペアドステートメント)
-        $stmt = $db->prepare('SELECT * FROM uploaded');
+        // 選択 (公開してよいファイル一覧用の列だけを取得)
+        $stmt = $db->prepare('SELECT ' . implode(', ', self::PUBLIC_FILE_COLUMNS) . ' FROM uploaded');
         $stmt->execute();
         $r = $stmt->fetchAll();
 

--- a/app/views/index.php
+++ b/app/views/index.php
@@ -135,5 +135,8 @@
 <!-- ファイルデータをJavaScriptに渡す -->
 <script>
   // PHPからJavaScriptにファイルデータを渡す
-  window.fileData = <?php echo json_encode($data, JSON_UNESCAPED_UNICODE); ?>;
+  window.fileData = <?php echo json_encode(
+      $data,
+      JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+  ); ?>;
 </script>

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "shimosyan/php-uploader",
     "description": "Simple PHP file uploader with download/delete authentication",
-    "version": "2.0.1",
+    "version": "2.0.2",
     "type": "project",
     "keywords": [
         "php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7100eff9699b168683251905789688b3",
+    "content-hash": "54024f0abdd6e9a428e765358839b367",
     "packages": [],
     "packages-dev": [
         {

--- a/tests/Unit/IndexModelTest.php
+++ b/tests/Unit/IndexModelTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use PHPUploader\Model\Index;
+
+final class IndexModelTest extends TestCase
+{
+    public function testPublicFileColumnsExcludeSensitiveDatabaseFields(): void
+    {
+        $publicColumns = Index::PUBLIC_FILE_COLUMNS;
+
+        self::assertSame(
+            [
+                'id',
+                'origin_file_name',
+                'comment',
+                'size',
+                'count',
+                'input_date',
+            ],
+            $publicColumns
+        );
+
+        self::assertNotContains('ip_address', $publicColumns);
+        self::assertNotContains('dl_key_hash', $publicColumns);
+        self::assertNotContains('del_key_hash', $publicColumns);
+        self::assertNotContains('stored_file_name', $publicColumns);
+        self::assertNotContains('file_hash', $publicColumns);
+    }
+}

--- a/tests/Unit/IndexViewTest.php
+++ b/tests/Unit/IndexViewTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+final class IndexViewTest extends TestCase
+{
+    public function testFileDataJsonUsesHexEscapingForInlineScriptSafety(): void
+    {
+        $data = [
+            [
+                'id' => 1,
+                'origin_file_name' => '</script><script>alert("x")</script>.pdf',
+                'comment' => "Tom & Jerry's file",
+            ],
+        ];
+
+        $json = json_encode(
+            $data,
+            JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+        );
+
+        self::assertIsString($json);
+        self::assertStringNotContainsString('</script>', $json);
+        self::assertStringContainsString('\\u003C\\/script\\u003E', $json);
+        self::assertStringContainsString('\\u0026', $json);
+        self::assertStringContainsString('\\u0027', $json);
+        self::assertStringContainsString('\\u0022', $json);
+    }
+}

--- a/tests/e2e/uploader.spec.js
+++ b/tests/e2e/uploader.spec.js
@@ -44,6 +44,22 @@ test.describe('phpUploader UI', () => {
 
     await expect(page.locator('.file-card-v2__filename')).toContainText('sample-upload.pdf');
 
+    const fileData = await page.evaluate(() => window.fileData);
+    expect(fileData).toHaveLength(1);
+    expect(fileData[0]).toEqual(expect.objectContaining({
+      id: expect.any(Number),
+      origin_file_name: 'sample-upload.pdf',
+      comment: '',
+      size: expect.any(Number),
+      count: expect.any(Number),
+      input_date: expect.any(Number)
+    }));
+    expect(fileData[0]).not.toHaveProperty('ip_address');
+    expect(fileData[0]).not.toHaveProperty('dl_key_hash');
+    expect(fileData[0]).not.toHaveProperty('del_key_hash');
+    expect(fileData[0]).not.toHaveProperty('stored_file_name');
+    expect(fileData[0]).not.toHaveProperty('file_hash');
+
     await page.locator('#fileSearchInput').fill('sample');
     await expect(page.locator('.file-card-v2__filename')).toContainText('sample-upload.pdf');
 


### PR DESCRIPTION
## Summary
- Limit uploaded file list data to public display columns only
- Add hex escaping when embedding file list JSON into the index page
- Add PHPUnit and Playwright regression coverage for exposed file metadata
- Bump package version and changelog to 2.0.2

## Verified
- composer test
- npm run test:e2e:docker
- bash scripts/check-quality.sh

## Release note
After this PR is merged, push tag `v2.0.2` from the merge commit to publish the GitHub Release via the existing release workflow.