### PR TITLE
chore: limit PHPUnit Renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -69,6 +69,16 @@
       automerge: true,
     },
     {
+      description: 'Keep PHPUnit compatible with the supported PHP runtime range',
+      matchManagers: [
+        'composer',
+      ],
+      matchPackageNames: [
+        'phpunit/phpunit',
+      ],
+      allowedVersions: '<11.0.0',
+    },
+    {
       matchSourceUrls: [
         'https://github.com/php/php-src',
       ],


### PR DESCRIPTION
## Summary
- Prevent Renovate from proposing PHPUnit 11+ while this project supports PHP 8.1
- Keep PHPUnit patch/minor updates available within the compatible 10.x range

## Context
PR #295 updates PHPUnit to 13.x, but PHPUnit 13 requires PHP >= 8.4.1. The current Composer constraint is PHP ^8.1 and CI runs PHP 8.1/8.3, so Composer fails before tests start.

## Testing
- git diff --check